### PR TITLE
Update SecureCheckValidator.php

### DIFF
--- a/Classes/Mvc/Validation/SecureCheckValidator.php
+++ b/Classes/Mvc/Validation/SecureCheckValidator.php
@@ -100,7 +100,6 @@ class SecureCheckValidator extends AbstractValidator
         foreach ($minimValues as $neededCheck) {
             $this->testCounter++;
             if (!array_key_exists($neededCheck, $checks)) {
-                $this->displayError();
                 return false;
             }
             $this->countValidTests++;


### PR DESCRIPTION
Dispaly error is called twice, once in the checkMinimumInfo function and right below caller.