### PR TITLE
[FEATURE] add auto inject functionality for v14, resolves #16

### DIFF
--- a/Classes/EventListener/AutoInjectListener.php
+++ b/Classes/EventListener/AutoInjectListener.php
@@ -1,0 +1,78 @@
+<?php
+
+/***
+ *
+ * This file is part of the "wsm_form_spamshield" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ *  (c) 2023 André Kraus <andre.kraus@website-mensch.de>, Website Mensch
+ *
+ ***/
+
+declare(strict_types=1);
+
+namespace WebsiteMensch\FormSpamshield\EventListener;
+
+use TYPO3\CMS\Core\Attribute\AsEventListener;
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
+use TYPO3\CMS\Core\Http\ApplicationType;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Form\Domain\Model\FormElements\FormElementInterface;
+use TYPO3\CMS\Form\Domain\Model\FormElements\Page;
+use TYPO3\CMS\Form\Event\AfterCurrentPageIsResolvedEvent;
+use WebsiteMensch\FormSpamshield\Mvc\Validation\SecureCheckValidator;
+
+#[AsEventListener(identifier: 'wsm-form-spamshield/auto-inject')]
+final class AutoInjectListener
+{
+    private const FIELD_ID = 'secureCheck';
+
+    private const ELEMENT_TYPE = 'SecureCheck';
+
+    public function __invoke(AfterCurrentPageIsResolvedEvent $event): void
+    {
+        $config = GeneralUtility::makeInstance(ExtensionConfiguration::class)
+            ->get('wsm_form_spamshield');
+
+        if (empty($config['autoInject'])) {
+            return;
+        }
+
+        // never touch the backend form editor preview.
+        $renderingOptions = $event->formRuntime->getFormDefinition()->getRenderingOptions();
+        if (($renderingOptions['previewMode'] ?? false)
+            || ApplicationType::fromRequest($event->request)->isBackend()
+        ) {
+            return;
+        }
+
+        // summary page doesn't render elements, so we skip it.
+        $targetPage = $event->currentPage ?? $event->lastDisplayedPage;
+        if ($targetPage === null || $targetPage->getType() === 'SummaryPage' || $this->hasSecureCheck($targetPage)) {
+            return;
+        }
+
+        // createElement applies the prototype properties (CSS class for the JS), but the validator has to be attached at runtime.
+        $element = $targetPage->createElement(self::FIELD_ID, self::ELEMENT_TYPE);
+        $validator = GeneralUtility::makeInstance(SecureCheckValidator::class);
+        $validator->setOptions([
+            'securityLevel' => (int)($config['securityLevel'] ?? 7),
+            'formTimeout' => (int)($config['formTimeout'] ?? 5),
+            'strictMode' => (bool)($config['strictMode'] ?? true),
+            'requireWhitespace' => (bool)($config['requireWhitespace'] ?? true),
+        ]);
+        $element->addValidator($validator);
+    }
+
+    private function hasSecureCheck(Page $page): bool
+    {
+        foreach ($page->getRenderablesRecursively() as $element) {
+            if ($element instanceof FormElementInterface && $element->getType() === self::ELEMENT_TYPE) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/Resources/Private/Language/Backend.xlf
+++ b/Resources/Private/Language/Backend.xlf
@@ -1,13 +1,31 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes" ?>
-<xliff version="1.0">
-    <file source-language="en" datatype="plaintext" original="messages" date="2019-06-14UTC21:34:060">
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file source-language="en" datatype="plaintext" original="EXT:form_spamshield/Resources/Private/Language/Backend.xlf" date="2026-06-18T16:29:37Z">
         <header>
             <authorName>Andre Kraus</authorName>
             <authorEmail>info@website-mensch.de</authorEmail>
         </header>
         <body>
+            <trans-unit id="setting.autoInject">
+                <source><![CDATA[Auto inject: add the spam SecureCheck to every form automatically]]></source>
+            </trans-unit>
+            <trans-unit id="setting.formTimeout">
+                <source><![CDATA[Form timeout: minimum seconds before a form may be sent]]></source>
+            </trans-unit>
+            <trans-unit id="setting.requireWhitespace">
+                <source><![CDATA[Require whitespace: expect at least one whitespace key press]]></source>
+            </trans-unit>
+            <trans-unit id="setting.securityLevel">
+                <source><![CDATA[Security level (1-10): percentage of checks that must pass]]></source>
+            </trans-unit>
+            <trans-unit id="setting.strictMode">
+                <source><![CDATA[Strict mode: validate all expected checks, not only submitted ones]]></source>
+            </trans-unit>
+            <trans-unit id="settingGroup.autoInject">
+                <source><![CDATA[Auto-inject]]></source>
+            </trans-unit>
             <trans-unit id="wsm.form_spamshield.title">
-                <source>Simple Spam Protection</source>
+                <source><![CDATA[Simple Spam Protection]]></source>
             </trans-unit>
         </body>
     </file>

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -1,0 +1,16 @@
+# customsubcategory=autoInject=LLL:EXT:wsm_form_spamshield/Resources/Private/Language/Backend.xlf:settingGroup.autoInject
+
+# cat=basic/autoInject/10; type=boolean; label=LLL:EXT:wsm_form_spamshield/Resources/Private/Language/Backend.xlf:setting.autoInject
+autoInject = 0
+
+# cat=basic/autoInject/20; type=int+; label=LLL:EXT:wsm_form_spamshield/Resources/Private/Language/Backend.xlf:setting.securityLevel
+securityLevel = 7
+
+# cat=basic/autoInject/30; type=int+; label=LLL:EXT:wsm_form_spamshield/Resources/Private/Language/Backend.xlf:setting.formTimeout
+formTimeout = 5
+
+# cat=basic/autoInject/40; type=boolean; label=LLL:EXT:wsm_form_spamshield/Resources/Private/Language/Backend.xlf:setting.strictMode
+strictMode = 1
+
+# cat=basic/autoInject/50; type=boolean; label=LLL:EXT:wsm_form_spamshield/Resources/Private/Language/Backend.xlf:setting.requireWhitespace
+requireWhitespace = 1


### PR DESCRIPTION
Updated PR for v14 branch of https://github.com/krausandre/wsm-form-spamshield/pull/25 

This adds an event listener for the AfterCurrentPageIsResolvedEvent event to automatically inject the SecureCheck element into every form page where it could get validated.

Following exceptions are respected:
- Backend Mode or Preview for hidden pages
- Summary Pages are excluded, no elements are rendered on summary pages, so validation would always fail
- if a SecureCheck element got manually added to the form that element will take priority and won't add another SecureCheck element. This allows individualisation for the security settings.